### PR TITLE
./node_modules/.bin is included during execution of npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "build-docs": "cd _docs/; jekyll build; touch ../docs/.nojekyll",
-    "build-docs-js": "./node_modules/.bin/webpack --config webpack.config.dev.js",
-    "build-dist": "./node_modules/.bin/webpack --config webpack.config.prod.js",
+    "build-docs-js": "webpack --config webpack.config.dev.js",
+    "build-dist": "webpack --config webpack.config.prod.js",
     "build": "npm-run-all build-docs-js build-docs build-dist",
-    "watch": "./node_modules/.bin/webpack --config webpack.config.dev.js --watch"
+    "watch": "webpack --config webpack.config.dev.js --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`./node_modules/.bin` is included during execution of npm scripts making the explicit path to the executable scripts in the scripts section of `package.json` redundant. 😊

Source: https://docs.npmjs.com/misc/scripts#path