### PR TITLE
Minor validation fixes to docs

### DIFF
--- a/_docs/_assets/scss/home.scss
+++ b/_docs/_assets/scss/home.scss
@@ -22,7 +22,7 @@ p.sv-home__text {
    letter-spacing: 3px;
 }
 
-h5.sv-home__subheader {
+.sv-home__subheader {
    font-size: 1.125em;
    font-weight: 400;
    margin: 0;
@@ -35,7 +35,7 @@ p.sv-home-media__text {
    margin: .125em 0;
 }
 
-button.sv-home-button__size {
+.sv-home-button__size {
    border-radius: .2em;
    font-size: 1em;
    line-height: 1.625em;

--- a/_docs/_includes/head.html
+++ b/_docs/_includes/head.html
@@ -11,8 +11,8 @@
 
 <link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="{{ site.baseurl }}/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="{{ site.baseurl }}/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="{{ site.baseurl }}/css/main.css" rel="stylesheet">

--- a/_docs/_includes/nav-top.html
+++ b/_docs/_includes/nav-top.html
@@ -1,6 +1,6 @@
 <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="{{ site.baseurl }}/assets/img/sitevision_logo.png"></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="{{ site.baseurl }}/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/_docs/_includes/nav-top.html
+++ b/_docs/_includes/nav-top.html
@@ -1,6 +1,6 @@
 <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="{{ site.baseurl }}/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="{{ site.baseurl }}/assets/img/sitevision_logo.png"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/_docs/components/alert.md
+++ b/_docs/components/alert.md
@@ -22,7 +22,7 @@ group: components
    <article class="env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/100x100.png">
+            <img class="env-image env-image--small" src="https://placehold.it/100x100.png" alt="">
          </a>
       </div>
       <div class="env-media__body">

--- a/_docs/components/feed.md
+++ b/_docs/components/feed.md
@@ -10,7 +10,7 @@ group: components
    <header class="env-post__header env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/250x250">
+            <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="">
          </a>
       </div>
       <div class="env-media__body">
@@ -63,7 +63,7 @@ group: components
          <div class="env-comments__comment env-media"> 
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png">
+                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -83,7 +83,7 @@ group: components
 <article class="env-comment env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -123,7 +123,7 @@ group: components
    <header class="env-post__header env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/250x250">
+            <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="">
          </a>
       </div>
       <div class="env-media__body">
@@ -167,7 +167,7 @@ group: components
                <article class="env-comment env-media">
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -204,7 +204,7 @@ group: components
                <article class="env-comment env-media">
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -241,7 +241,7 @@ group: components
                <article class="env-comment env-media">
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -278,7 +278,7 @@ group: components
          <div class="env-comments__comment env-media"> 
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png">
+                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -299,7 +299,7 @@ group: components
    <header class="env-post__header env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/250x250">
+            <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="">
          </a>
       </div>
       <div class="env-media__body">
@@ -328,7 +328,7 @@ group: components
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250">
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -366,7 +366,7 @@ group: components
          <div class="env-comments__comment env-media"> 
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png">
+                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -389,7 +389,7 @@ group: components
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250">
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -433,7 +433,7 @@ group: components
                      <article class="env-comment env-media">
                         <div class="env-media__figure">
                            <a href="#">
-                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
                            </a>
                         </div>
                         <div class="env-media__body">
@@ -470,7 +470,7 @@ group: components
                      <article class="env-comment env-media">
                         <div class="env-media__figure">
                            <a href="#">
-                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
                            </a>
                         </div>
                         <div class="env-media__body">
@@ -507,7 +507,7 @@ group: components
                <div class="env-comments__comment env-media"> 
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png">
+                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="">
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -526,7 +526,7 @@ group: components
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250">
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -570,7 +570,7 @@ group: components
                <div class="env-comments__comment env-media"> 
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png">
+                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="">
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -589,7 +589,7 @@ group: components
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250">
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -633,7 +633,7 @@ group: components
                <div class="env-comments__comment env-media"> 
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png">
+                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="">
                      </a>
                   </div>
                   <div class="env-media__body">

--- a/_docs/components/media.md
+++ b/_docs/components/media.md
@@ -10,7 +10,7 @@ group: components
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -30,7 +30,7 @@ group: components
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -58,7 +58,7 @@ group: components
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body env-media__body--inline">
@@ -78,7 +78,7 @@ group: components
 <article class="env-media env-media--column">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image" src="https://placehold.it/200x200.png">
+         <img class="env-image" src="https://placehold.it/200x200.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -100,7 +100,7 @@ group: components
 <article class="env-media env-media--center">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -119,7 +119,7 @@ group: components
 <article class="env-media env-media--column env-media--center">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image" src="https://placehold.it/200x200.png">
+         <img class="env-image" src="https://placehold.it/200x200.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -140,7 +140,7 @@ Alignment modifiers can also be applied to elements within the media container (
 <article class="env-media env-media--column env-media">
    <div class="env-media__figure env-media__figure--center">
       <a href="#">
-         <img class="env-image" src="https://placehold.it/200x200.png">
+         <img class="env-image" src="https://placehold.it/200x200.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -160,7 +160,7 @@ Alignment modifiers can also be applied to elements within the media container (
 <article class="env-media env-media--bottom">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -182,7 +182,7 @@ Alignment modifiers can also be applied to elements within the media container (
 <article class="env-media env-media--reverse">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -203,7 +203,7 @@ Alignment modifiers can also be applied to elements within the media container (
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
       </a>
    </div>
    <div class="env-media__body">
@@ -217,7 +217,7 @@ Alignment modifiers can also be applied to elements within the media container (
       <article class="env-media">
          <div class="env-media__figure">
             <a href="#">
-               <img class="env-image env-image--small" src="https://placehold.it/400x400.png">
+               <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="">
             </a>
          </div>
          <div class="env-media__body">

--- a/_docs/components/news-item.md
+++ b/_docs/components/news-item.md
@@ -13,7 +13,7 @@ group: components
 
 <article class="env-news-item">
    <div class="env-news-item__media">
-      <img src="https://unsplash.it/467/300/?blur" />
+      <img src="https://unsplash.it/467/300/?blur" alt="" />
    </div>
    <header class="env-news-item__headline">
       <div class="env-news-item__headline__title">
@@ -50,7 +50,7 @@ group: components
       <li class="env-list__item">
          <article class="env-news-item">
             <div class="env-news-item__media">
-               <img src="https://unsplash.it/467/300/?blur" />
+               <img src="https://unsplash.it/467/300/?blur" alt="" />
             </div>
             <header class="env-news-item__headline">
                <div class="env-news-item__headline__title">
@@ -83,7 +83,7 @@ group: components
       <li class="env-list__item">
          <article class="env-news-item">
             <div class="env-news-item__media">
-               <img src="https://unsplash.it/467/300/?blur" />
+               <img src="https://unsplash.it/467/300/?blur" alt="" />
             </div>
             <header class="env-news-item__headline">
                <div class="env-news-item__headline__title">
@@ -116,7 +116,7 @@ group: components
       <li class="env-list__item">
          <article class="env-news-item">
             <div class="env-news-item__media">
-               <img src="https://unsplash.it/467/300/?blur" />
+               <img src="https://unsplash.it/467/300/?blur" alt="" />
             </div>
             <header class="env-news-item__headline">
                <div class="env-news-item__headline__title">
@@ -155,7 +155,7 @@ group: components
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -188,7 +188,7 @@ group: components
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -221,7 +221,7 @@ group: components
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -254,7 +254,7 @@ group: components
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -287,7 +287,7 @@ group: components
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -320,7 +320,7 @@ group: components
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">

--- a/_docs/index.html
+++ b/_docs/index.html
@@ -5,11 +5,11 @@ layout: home
    <div class="env-d--flex env-justify-content--center sv-home__content">
       <div class="env-p-around--xxx-large sv-home__item">
          <h1 class="sv-home__title env-m-bottom--xxx-small">{{ site.project_name }}</h1>
-         <h5 class="sv-home__subheader">Create SiteVision like components and modules the easy way!</h5>
+         <h2 class="sv-home__subheader">Create SiteVision like components and modules the easy way!</h2>
          <p class="env-p-top--large sv-home__text env-m-bottom--large">Envision is a easy to use, open source, CSS and component framework for developing with HTML, CSS, and JS. Envision uses Block, Element, Modifier methodology, BEM is a popular naming convention for classes in HTML and CSS. Find out more about <a href="https://en.bem.info/methodology/quick-start/">BEM here.</a></p>
          <div class="env-p-top--large env-m-bottom--xxx-large">
-            <button type="button" class="env-button sv-home-button__size env-button--primary env-m-right--x-small"><a class="env-color--lightest" href="{{ site.baseurl }}/getting-started/introduction/">Get started</a></button>
-            <button type="button" class="env-button sv-home-button__size env-button--link env-border"><a href="https://github.com/sitevision/envision/archive/master.zip">Download</a></button>
+            <a class="env-button sv-home-button__size env-button--primary env-m-right--x-small env-color--lightest" href="{{ site.baseurl }}/getting-started/introduction/">Get started</a>
+            <a class="env-button sv-home-button__size env-button--link env-border" href="https://github.com/sitevision/envision/archive/master.zip">Download</a>
          </div>
 
          <article class="env-media env-media--center env-p-top--xxx-large">

--- a/_docs/index.html
+++ b/_docs/index.html
@@ -27,7 +27,7 @@ layout: home
          </article>
       </div>
       <div class="env-p-around--xxx-large sv-home__item sv-home__env-logo">
-         <img class="env-image" src="{{ site.baseurl }}/assets/img/logo_icon.png" }}>
+         <img class="env-image" src="{{ site.baseurl }}/assets/img/logo_icon.png">
       </div>
    </div>
 </main>

--- a/_docs/index.html
+++ b/_docs/index.html
@@ -5,10 +5,10 @@ layout: home
    <div class="env-d--flex env-justify-content--center sv-home__content">
       <div class="env-p-around--xxx-large sv-home__item">
          <h1 class="sv-home__title env-m-bottom--xxx-small">{{ site.project_name }}</h1>
-         <h5 class="sv-home__subheader">Create SiteVision like components and modules the easy way!</h3>
+         <h5 class="sv-home__subheader">Create SiteVision like components and modules the easy way!</h5>
          <p class="env-p-top--large sv-home__text env-m-bottom--large">Envision is a easy to use, open source, CSS and component framework for developing with HTML, CSS, and JS. Envision uses Block, Element, Modifier methodology, BEM is a popular naming convention for classes in HTML and CSS. Find out more about <a href="https://en.bem.info/methodology/quick-start/">BEM here.</a></p>
          <div class="env-p-top--large env-m-bottom--xxx-large">
-            <button type="button" class="env-button sv-home-button__size env-button--primary env-m-right--x-small"><a class="env-color--lightest"href="{{ site.baseurl }}/getting-started/introduction/">Get started</a></button>
+            <button type="button" class="env-button sv-home-button__size env-button--primary env-m-right--x-small"><a class="env-color--lightest" href="{{ site.baseurl }}/getting-started/introduction/">Get started</a></button>
             <button type="button" class="env-button sv-home-button__size env-button--link env-border"><a href="https://github.com/sitevision/envision/archive/master.zip">Download</a></button>
          </div>
 

--- a/_docs/index.html
+++ b/_docs/index.html
@@ -15,7 +15,7 @@ layout: home
          <article class="env-media env-media--center env-p-top--xxx-large">
             <div class="env-media__figure env-p-right--small">
                <a href="{{ site.baseurl }}/assets/img/envision.psd">
-                  <img class="env-image env-image--medium" src="{{ site.baseurl }}/assets/img/ps.png">
+                  <img class="env-image env-image--medium" src="{{ site.baseurl }}/assets/img/ps.png" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -27,7 +27,7 @@ layout: home
          </article>
       </div>
       <div class="env-p-around--xxx-large sv-home__item sv-home__env-logo">
-         <img class="env-image" src="{{ site.baseurl }}/assets/img/logo_icon.png">
+         <img class="env-image" src="{{ site.baseurl }}/assets/img/logo_icon.png" alt="">
       </div>
    </div>
 </main>

--- a/docs/about/contributors/index.html
+++ b/docs/about/contributors/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/alert/index.html
+++ b/docs/components/alert/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">
@@ -568,7 +568,7 @@
    <article class="env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/100x100.png" />
+            <img class="env-image env-image--small" src="https://placehold.it/100x100.png" alt="" />
          </a>
       </div>
       <div class="env-media__body">
@@ -587,7 +587,7 @@
    <span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
          <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/100x100.png"</span><span class="nt">&gt;</span>
+            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/100x100.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
          <span class="nt">&lt;/a&gt;</span>
       <span class="nt">&lt;/div&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>

--- a/docs/components/badge/index.html
+++ b/docs/components/badge/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/breadcrumb/index.html
+++ b/docs/components/breadcrumb/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/button-group/index.html
+++ b/docs/components/button-group/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/button/index.html
+++ b/docs/components/button/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/dropdown/index.html
+++ b/docs/components/dropdown/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/embedded/index.html
+++ b/docs/components/embedded/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/feed/index.html
+++ b/docs/components/feed/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">
@@ -550,7 +550,7 @@
    <header class="env-post__header env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/250x250" />
+            <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="" />
          </a>
       </div>
       <div class="env-media__body">
@@ -603,7 +603,7 @@
          <div class="env-comments__comment env-media"> 
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" />
+                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="" />
                </a>
             </div>
             <div class="env-media__body">
@@ -621,7 +621,7 @@
    <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-post__header env-media"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
          <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span><span class="nt">&gt;</span>
+            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
          <span class="nt">&lt;/a&gt;</span>
       <span class="nt">&lt;/div&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -674,7 +674,7 @@
          <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-comments__comment env-media"</span><span class="nt">&gt;</span> 
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                <span class="nt">&lt;/a&gt;</span>
             <span class="nt">&lt;/div&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -694,7 +694,7 @@
 <article class="env-comment env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -730,7 +730,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-comment env-media"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -770,7 +770,7 @@
    <header class="env-post__header env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/250x250" />
+            <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="" />
          </a>
       </div>
       <div class="env-media__body">
@@ -814,7 +814,7 @@
                <article class="env-comment env-media">
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -851,7 +851,7 @@
                <article class="env-comment env-media">
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -888,7 +888,7 @@
                <article class="env-comment env-media">
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+                        <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -925,7 +925,7 @@
          <div class="env-comments__comment env-media"> 
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" />
+                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="" />
                </a>
             </div>
             <div class="env-media__body">
@@ -943,7 +943,7 @@
    <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-post__header env-media"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
          <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span><span class="nt">&gt;</span>
+            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
          <span class="nt">&lt;/a&gt;</span>
       <span class="nt">&lt;/div&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -987,7 +987,7 @@
                <span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-comment env-media"</span><span class="nt">&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;/a&gt;</span>
                   <span class="nt">&lt;/div&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1024,7 +1024,7 @@
                <span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-comment env-media"</span><span class="nt">&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;/a&gt;</span>
                   <span class="nt">&lt;/div&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1061,7 +1061,7 @@
                <span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-comment env-media"</span><span class="nt">&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;/a&gt;</span>
                   <span class="nt">&lt;/div&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1098,7 +1098,7 @@
          <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-comments__comment env-media"</span><span class="nt">&gt;</span> 
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                <span class="nt">&lt;/a&gt;</span>
             <span class="nt">&lt;/div&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1119,7 +1119,7 @@
    <header class="env-post__header env-media">
       <div class="env-media__figure">
          <a href="#">
-            <img class="env-image env-image--small" src="https://placehold.it/250x250" />
+            <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="" />
          </a>
       </div>
       <div class="env-media__body">
@@ -1148,7 +1148,7 @@
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250" />
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="" />
                </a>
             </div>
             <div class="env-media__body">
@@ -1186,7 +1186,7 @@
          <div class="env-comments__comment env-media"> 
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" />
+                  <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="" />
                </a>
             </div>
             <div class="env-media__body">
@@ -1204,7 +1204,7 @@
    <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-post__header env-media"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
          <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span><span class="nt">&gt;</span>
+            <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
          <span class="nt">&lt;/a&gt;</span>
       <span class="nt">&lt;/div&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1233,7 +1233,7 @@
          <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-post__header env-media"</span><span class="nt">&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span><span class="nt">&gt;</span>
+                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                <span class="nt">&lt;/a&gt;</span>
             <span class="nt">&lt;/div&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1271,7 +1271,7 @@
          <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-comments__comment env-media"</span><span class="nt">&gt;</span> 
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                <span class="nt">&lt;/a&gt;</span>
             <span class="nt">&lt;/div&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1294,7 +1294,7 @@
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250" />
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="" />
                </a>
             </div>
             <div class="env-media__body">
@@ -1338,7 +1338,7 @@
                      <article class="env-comment env-media">
                         <div class="env-media__figure">
                            <a href="#">
-                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
                            </a>
                         </div>
                         <div class="env-media__body">
@@ -1375,7 +1375,7 @@
                      <article class="env-comment env-media">
                         <div class="env-media__figure">
                            <a href="#">
-                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+                              <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
                            </a>
                         </div>
                         <div class="env-media__body">
@@ -1412,7 +1412,7 @@
                <div class="env-comments__comment env-media"> 
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" />
+                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="" />
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -1431,7 +1431,7 @@
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250" />
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="" />
                </a>
             </div>
             <div class="env-media__body">
@@ -1475,7 +1475,7 @@
                <div class="env-comments__comment env-media"> 
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" />
+                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="" />
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -1494,7 +1494,7 @@
          <header class="env-post__header env-media">
             <div class="env-media__figure">
                <a href="#">
-                  <img class="env-image env-image--small" src="https://placehold.it/250x250" />
+                  <img class="env-image env-image--small" src="https://placehold.it/250x250" alt="" />
                </a>
             </div>
             <div class="env-media__body">
@@ -1538,7 +1538,7 @@
                <div class="env-comments__comment env-media"> 
                   <div class="env-media__figure">
                      <a href="#">
-                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" />
+                        <img class="env-image env-image--tiny" src="https://placehold.it/400x400.png" alt="" />
                      </a>
                   </div>
                   <div class="env-media__body">
@@ -1560,7 +1560,7 @@
          <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-post__header env-media"</span><span class="nt">&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span><span class="nt">&gt;</span>
+                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                <span class="nt">&lt;/a&gt;</span>
             <span class="nt">&lt;/div&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1604,7 +1604,7 @@
                      <span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-comment env-media"</span><span class="nt">&gt;</span>
                         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                            <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                              <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                              <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                            <span class="nt">&lt;/a&gt;</span>
                         <span class="nt">&lt;/div&gt;</span>
                         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1641,7 +1641,7 @@
                      <span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-comment env-media"</span><span class="nt">&gt;</span>
                         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                            <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                              <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                              <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                            <span class="nt">&lt;/a&gt;</span>
                         <span class="nt">&lt;/div&gt;</span>
                         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1678,7 +1678,7 @@
                <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-comments__comment env-media"</span><span class="nt">&gt;</span> 
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;/a&gt;</span>
                   <span class="nt">&lt;/div&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1697,7 +1697,7 @@
          <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-post__header env-media"</span><span class="nt">&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span><span class="nt">&gt;</span>
+                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                <span class="nt">&lt;/a&gt;</span>
             <span class="nt">&lt;/div&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1741,7 +1741,7 @@
                <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-comments__comment env-media"</span><span class="nt">&gt;</span> 
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;/a&gt;</span>
                   <span class="nt">&lt;/div&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1760,7 +1760,7 @@
          <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-post__header env-media"</span><span class="nt">&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span><span class="nt">&gt;</span>
+                  <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/250x250"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                <span class="nt">&lt;/a&gt;</span>
             <span class="nt">&lt;/div&gt;</span>
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -1804,7 +1804,7 @@
                <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-comments__comment env-media"</span><span class="nt">&gt;</span> 
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+                        <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--tiny"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
                      <span class="nt">&lt;/a&gt;</span>
                   <span class="nt">&lt;/div&gt;</span>
                   <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>

--- a/docs/components/form/index.html
+++ b/docs/components/form/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/image-slider/index.html
+++ b/docs/components/image-slider/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/image-viewer/index.html
+++ b/docs/components/image-viewer/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/list/index.html
+++ b/docs/components/list/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/media/index.html
+++ b/docs/components/media/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">
@@ -550,7 +550,7 @@
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -567,7 +567,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -587,7 +587,7 @@
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -612,7 +612,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -640,7 +640,7 @@
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body env-media__body--inline">
@@ -657,7 +657,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body env-media__body--inline"</span><span class="nt">&gt;</span>
@@ -677,7 +677,7 @@
 <article class="env-media env-media--column">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image" src="https://placehold.it/200x200.png" />
+         <img class="env-image" src="https://placehold.it/200x200.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -694,7 +694,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media env-media--column"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image"</span> <span class="na">src=</span><span class="s">"https://placehold.it/200x200.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image"</span> <span class="na">src=</span><span class="s">"https://placehold.it/200x200.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -716,7 +716,7 @@
 <article class="env-media env-media--center">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -733,7 +733,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media env-media--center"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -751,7 +751,7 @@
 <article class="env-media env-media--column env-media--center">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image" src="https://placehold.it/200x200.png" />
+         <img class="env-image" src="https://placehold.it/200x200.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -768,7 +768,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media env-media--column env-media--center"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image"</span> <span class="na">src=</span><span class="s">"https://placehold.it/200x200.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image"</span> <span class="na">src=</span><span class="s">"https://placehold.it/200x200.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -788,7 +788,7 @@
 <article class="env-media env-media--column env-media">
    <div class="env-media__figure env-media__figure--center">
       <a href="#">
-         <img class="env-image" src="https://placehold.it/200x200.png" />
+         <img class="env-image" src="https://placehold.it/200x200.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -805,7 +805,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media env-media--column env-media"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure env-media__figure--center"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image"</span> <span class="na">src=</span><span class="s">"https://placehold.it/200x200.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image"</span> <span class="na">src=</span><span class="s">"https://placehold.it/200x200.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -825,7 +825,7 @@
 <article class="env-media env-media--bottom">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -842,7 +842,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media env-media--bottom"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -864,7 +864,7 @@
 <article class="env-media env-media--reverse">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -881,7 +881,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media env-media--reverse"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -901,7 +901,7 @@
 <article class="env-media">
    <div class="env-media__figure">
       <a href="#">
-         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+         <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
       </a>
    </div>
    <div class="env-media__body">
@@ -915,7 +915,7 @@
       <article class="env-media">
          <div class="env-media__figure">
             <a href="#">
-               <img class="env-image env-image--small" src="https://placehold.it/400x400.png" />
+               <img class="env-image env-image--small" src="https://placehold.it/400x400.png" alt="" />
             </a>
          </div>
          <div class="env-media__body">
@@ -934,7 +934,7 @@
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+         <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
       <span class="nt">&lt;/a&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>
@@ -948,7 +948,7 @@
       <span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-media"</span><span class="nt">&gt;</span>
          <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__figure"</span><span class="nt">&gt;</span>
             <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
-               <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span><span class="nt">&gt;</span>
+               <span class="nt">&lt;img</span> <span class="na">class=</span><span class="s">"env-image env-image--small"</span> <span class="na">src=</span><span class="s">"https://placehold.it/400x400.png"</span> <span class="na">alt=</span><span class="s">""</span><span class="nt">&gt;</span>
             <span class="nt">&lt;/a&gt;</span>
          <span class="nt">&lt;/div&gt;</span>
          <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-media__body"</span><span class="nt">&gt;</span>

--- a/docs/components/modal-dialog/index.html
+++ b/docs/components/modal-dialog/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/navigation/index.html
+++ b/docs/components/navigation/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/news-item/index.html
+++ b/docs/components/news-item/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">
@@ -550,7 +550,7 @@
 <div class="code-example" data-example-id="">
 <article class="env-news-item">
    <div class="env-news-item__media">
-      <img src="https://unsplash.it/467/300/?blur" />
+      <img src="https://unsplash.it/467/300/?blur" alt="" />
    </div>
    <header class="env-news-item__headline">
       <div class="env-news-item__headline__title">
@@ -582,7 +582,7 @@
 </div>
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;article</span> <span class="na">class=</span><span class="s">"env-news-item"</span><span class="nt">&gt;</span>
    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-news-item__media"</span><span class="nt">&gt;</span>
-      <span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"https://unsplash.it/467/300/?blur"</span> <span class="nt">/&gt;</span>
+      <span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"https://unsplash.it/467/300/?blur"</span> <span class="na">alt=</span><span class="s">""</span> <span class="nt">/&gt;</span>
    <span class="nt">&lt;/div&gt;</span>
    <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"env-news-item__headline"</span><span class="nt">&gt;</span>
       <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"env-news-item__headline__title"</span><span class="nt">&gt;</span>
@@ -618,7 +618,7 @@
       <li class="env-list__item">
          <article class="env-news-item">
             <div class="env-news-item__media">
-               <img src="https://unsplash.it/467/300/?blur" />
+               <img src="https://unsplash.it/467/300/?blur" alt="" />
             </div>
             <header class="env-news-item__headline">
                <div class="env-news-item__headline__title">
@@ -651,7 +651,7 @@
       <li class="env-list__item">
          <article class="env-news-item">
             <div class="env-news-item__media">
-               <img src="https://unsplash.it/467/300/?blur" />
+               <img src="https://unsplash.it/467/300/?blur" alt="" />
             </div>
             <header class="env-news-item__headline">
                <div class="env-news-item__headline__title">
@@ -684,7 +684,7 @@
       <li class="env-list__item">
          <article class="env-news-item">
             <div class="env-news-item__media">
-               <img src="https://unsplash.it/467/300/?blur" />
+               <img src="https://unsplash.it/467/300/?blur" alt="" />
             </div>
             <header class="env-news-item__headline">
                <div class="env-news-item__headline__title">
@@ -722,7 +722,7 @@
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -755,7 +755,7 @@
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -788,7 +788,7 @@
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -821,7 +821,7 @@
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -854,7 +854,7 @@
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">
@@ -887,7 +887,7 @@
    <li class="env-list__item">
       <article class="env-news-item">
          <div class="env-news-item__media">
-            <img src="https://unsplash.it/300/100/?blur" />
+            <img src="https://unsplash.it/300/100/?blur" alt="" />
          </div>
          <header class="env-news-item__headline">
             <div class="env-news-item__headline__title">

--- a/docs/components/pagination/index.html
+++ b/docs/components/pagination/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/popover/index.html
+++ b/docs/components/popover/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/progress/index.html
+++ b/docs/components/progress/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/range-slider/index.html
+++ b/docs/components/range-slider/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/spinner/index.html
+++ b/docs/components/spinner/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/tab/index.html
+++ b/docs/components/tab/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/components/table/index.html
+++ b/docs/components/table/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -239,7 +239,7 @@ p.sv-home__text {
   font-weight: bold;
   letter-spacing: 3px; }
 
-h5.sv-home__subheader {
+.sv-home__subheader {
   font-size: 1.125em;
   font-weight: 400;
   margin: 0; }
@@ -250,7 +250,7 @@ p.sv-home-media__text {
   line-height: 1.3em;
   margin: .125em 0; }
 
-button.sv-home-button__size {
+.sv-home-button__size {
   border-radius: .2em;
   font-size: 1em;
   line-height: 1.625em;

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/getting-started/introduction/index.html
+++ b/docs/getting-started/introduction/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,17 +13,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
   </head>
   <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">
@@ -47,17 +47,17 @@
    <div class="env-d--flex env-justify-content--center sv-home__content">
       <div class="env-p-around--xxx-large sv-home__item">
          <h1 class="sv-home__title env-m-bottom--xxx-small">Envision</h1>
-         <h5 class="sv-home__subheader">Create SiteVision like components and modules the easy way!</h3>
+         <h2 class="sv-home__subheader">Create SiteVision like components and modules the easy way!</h2>
          <p class="env-p-top--large sv-home__text env-m-bottom--large">Envision is a easy to use, open source, CSS and component framework for developing with HTML, CSS, and JS. Envision uses Block, Element, Modifier methodology, BEM is a popular naming convention for classes in HTML and CSS. Find out more about <a href="https://en.bem.info/methodology/quick-start/">BEM here.</a></p>
          <div class="env-p-top--large env-m-bottom--xxx-large">
-            <button type="button" class="env-button sv-home-button__size env-button--primary env-m-right--x-small"><a class="env-color--lightest"href="/getting-started/introduction/">Get started</a></button>
-            <button type="button" class="env-button sv-home-button__size env-button--link env-border"><a href="https://github.com/sitevision/envision/archive/master.zip">Download</a></button>
+            <a class="env-button sv-home-button__size env-button--primary env-m-right--x-small env-color--lightest" href="/getting-started/introduction/">Get started</a>
+            <a class="env-button sv-home-button__size env-button--link env-border" href="https://github.com/sitevision/envision/archive/master.zip">Download</a>
          </div>
 
          <article class="env-media env-media--center env-p-top--xxx-large">
             <div class="env-media__figure env-p-right--small">
                <a href="/assets/img/envision.psd">
-                  <img class="env-image env-image--medium" src="/assets/img/ps.png">
+                  <img class="env-image env-image--medium" src="/assets/img/ps.png" alt="">
                </a>
             </div>
             <div class="env-media__body">
@@ -69,7 +69,7 @@
          </article>
       </div>
       <div class="env-p-around--xxx-large sv-home__item sv-home__env-logo">
-         <img class="env-image" src="/assets/img/logo_icon.png" }}>
+         <img class="env-image" src="/assets/img/logo_icon.png" alt="">
       </div>
    </div>
 </main>

--- a/docs/utils/accessibility/index.html
+++ b/docs/utils/accessibility/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/borders/index.html
+++ b/docs/utils/borders/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/colors/index.html
+++ b/docs/utils/colors/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/display/index.html
+++ b/docs/utils/display/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/flexbox/index.html
+++ b/docs/utils/flexbox/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/icons/index.html
+++ b/docs/utils/icons/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/sizing/index.html
+++ b/docs/utils/sizing/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/spacing/index.html
+++ b/docs/utils/spacing/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/text/index.html
+++ b/docs/utils/text/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">

--- a/docs/utils/vertical-alignment/index.html
+++ b/docs/utils/vertical-alignment/index.html
@@ -12,17 +12,17 @@
 
 <link rel="icon" type="image/png" href="/assets/img/logo_icon.png" sizes="32x32">
 
-<!-- Documentation extras -->
-<link href="/css/main.css" rel="stylesheet">
-
 <!-- Bootstrap core CSS -->
 <link href="/assets/envision/envision.css" rel="stylesheet">
+
+<!-- Documentation extras -->
+<link href="/css/main.css" rel="stylesheet">
 
    </head>
    <body>
       <div class="env-w-100 sv-header">
    <header class="header env-p-top--small env-p-bottom--small">
-      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" }}></a></div>
+      <div class="logo env-m-left--medium"><a href="https://www.sitevision.se"><img src="/assets/img/sitevision_logo.png" alt="SiteVision"></a></div>
         <nav class="header-nav env-m-right--medium">
             <ul class="env-nav env-nav--menubar env-nav--border" role="menubar">
                <li class="env-nav__item" role="none">


### PR DESCRIPTION
I made some minor changes to the docs which addresses validation errors.

Please note that I haven't commited any generated files. Due to #68 :)

* Added empty `alt` attribute to images which didn't have the attribute before and which I also assumed were decorative images. There's a neat and fresh blog article addressing this topic over at [Axess lab](https://axesslab.com/alt-texts/).
* Fixed some issues with excessive invalid Liquid markup which weren't parsed.
* Removed unnecessary buttons which were wrapping links.
* Fixed issue in heading structure.
* Placed docs css link _after_ envision css link so css rules with same specificity would override correctly.
* Removed superfluous elements from selectors. The ones in question aren't needed anymore due to the new css link order above.