### PR TITLE
close popover on click outside

### DIFF
--- a/packages/envision/src/js/popover.js
+++ b/packages/envision/src/js/popover.js
@@ -258,9 +258,10 @@ const Popover = (($) => {
       }
 
       clickOutsideHandler(e) {
-         const $target = $(e.target);
+         const target = e.target;
+         const $target = $(target);
 
-         if (this.isShowing && !$target.is(this.$el) && !$target.closest(this.$popoverElement).length) {
+         if (this.isShowing && !this.el.contains(target) && !$target.closest(this.$popoverElement).length) {
             this.hide();
          }
       }


### PR DESCRIPTION
Popover does not work in combination with attribute: data-click-outside="true"
If click is made on an element within the button