### PR TITLE
Remove underline on links

### DIFF
--- a/packages/envision/src/scss/dropdown.scss
+++ b/packages/envision/src/scss/dropdown.scss
@@ -27,6 +27,7 @@
       display: block;
       padding: $spacing-x-small;
       @include truncate-text();
+      text-decoration: none;
 
       &:hover {
          background-color: rgba(0, 0, 0, .1);


### PR DESCRIPTION
Links inherited underline from "body a" in site settings.