### PR TITLE
Modal width bugfix

### DIFF
--- a/packages/envision/src/scss/modal-dialog.scss
+++ b/packages/envision/src/scss/modal-dialog.scss
@@ -43,14 +43,15 @@
       // Optimized for Chrome, shoudn't matter too much in other browsers.
       margin: 1em 14px 1em 10px;
       white-space: normal;
-      max-width: css-var('modal-medium-width');
+      width: css-var('modal-medium-width');
+      max-width: calc(100% - 30px);
 
       &--large {
-         max-width: css-var('modal-large-width');
+         width: css-var('modal-large-width');
       }
 
       &--small {
-         max-width: css-var('modal-small-width');
+         width: css-var('modal-small-width');
       }
    }
 

--- a/packages/envision/src/scss/modal-dialog.scss
+++ b/packages/envision/src/scss/modal-dialog.scss
@@ -8,7 +8,6 @@
    left: 0;
    outline: 0;
    overflow-x: hidden;
-   overflow-y: auto;
    transition: opacity 0.3s linear;
    z-index: $zindex-modal;
    white-space: nowrap;
@@ -35,7 +34,6 @@
       text-align: left;
       vertical-align: middle;
       display: inline-block;
-      overflow: auto;
       word-wrap: break-word;
       overflow-wrap: anywhere;
       word-break: normal;


### PR DESCRIPTION
Med för lite innehåll i modalen krympte den (anpassade sig till innehållet). Denna ändring gör att den får sin valda bredd.