### PR TITLE
ENV-194, ENV-200 Tab component fixes

### DIFF
--- a/packages/envision-docs/src/pages/components/tab.md
+++ b/packages/envision-docs/src/pages/components/tab.md
@@ -9,71 +9,20 @@ Note: All examples below require tabs to be [initialized from JavaScript](#init)
 ```html
 <div class="env-tabs example-tabs">
    <ul class="env-tabs__nav env-tabs__nav--border-bottom" role="tablist">
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab1"
-            class="env-tabs__link env-tabs__link--active"
-            href="#panel1"
-            role="tab"
-            aria-controls="panel1"
-            aria-selected="true"
-            >Tab 1</a
-         >
-      </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab2"
-            class="env-tabs__link"
-            href="#panel2"
-            role="tab"
-            aria-controls="panel2"
-            aria-selected="false"
-            >Tab 2</a
-         >
-      </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab3"
-            class="env-tabs__link"
-            href="#panel3"
-            role="tab"
-            aria-controls="panel3"
-            aria-selected="false"
-            >Tab 3</a
-         >
-      </li>
+      <li role="tab" aria-controls="panel1" aria-selected="false">Tab 1</li>
+      <li role="tab" aria-controls="panel2" aria-selected="true">Tab 2</li>
+      <li role="tab" aria-controls="panel3" aria-selected="false">Tab 3</li>
    </ul>
 </div>
-<a
-   href="#"
-   id="panel1"
-   class="example-panel"
-   aria-labelledby="tab1"
-   role="tabpanel"
-   aria-hidden="false"
->
+<div id="panel1" class="example-panel" role="tabpanel" aria-hidden="false">
    1
-</a>
-<a
-   href="#"
-   id="panel2"
-   class="example-panel"
-   aria-labelledby="tab2"
-   role="tabpanel"
-   aria-hidden="true"
->
+</div>
+<div id="panel2" class="example-panel" role="tabpanel" aria-hidden="true">
    2
-</a>
-<a
-   href="#"
-   id="panel3"
-   class="example-panel"
-   aria-labelledby="tab3"
-   role="tabpanel"
-   aria-hidden="true"
->
+</div>
+<div id="panel3" class="example-panel" role="tabpanel" aria-hidden="true">
    3
-</a>
+</div>
 ```
 
 ## Simple Tab
@@ -81,37 +30,26 @@ Note: All examples below require tabs to be [initialized from JavaScript](#init)
 ```html
 <div class="env-tabs env-tabs--simple example-tabs1">
    <ul class="env-tabs__nav" role="tablist">
-      <li class="env-tabs__item" role="presentation">
-         <a
+         <li
             id="tab4"
-            class="env-tabs__link env-tabs__link--active"
-            href="#panel4"
             role="tab"
             aria-controls="panel4"
-            aria-selected="true"
-            >Tab 4</a
+            aria-selected="false"
+            >Tab 4</li
          >
-      </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
+         <li
             id="tab5"
-            class="env-tabs__link"
-            href="#panel5"
             role="tab"
             aria-controls="panel5"
-            aria-selected="false"
-            >Tab 5</a
+            aria-selected="true"
+            >Tab 5</li
          >
-      </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
+         <li
             id="tab6"
-            class="env-tabs__link"
-            href="#panel6"
             role="tab"
             aria-controls="panel6"
             aria-selected="false"
-            >Tab 6</a
+            >Tab 6</li
          >
       </li>
    </ul>
@@ -151,38 +89,14 @@ Note: All examples below require tabs to be [initialized from JavaScript](#init)
 ```html
 <div class="env-tabs env-tabs--hover-fill example-tabs2">
    <ul class="env-tabs__nav" role="tablist">
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab7"
-            class="env-tabs__link env-tabs__link--active"
-            href="#panel7"
-            role="tab"
-            aria-controls="panel7"
-            aria-selected="true"
-            >Tab 7</a
-         >
+      <li id="tab7" role="tab" aria-controls="panel7" aria-selected="true">
+         Tab 7
       </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab8"
-            class="env-tabs__link"
-            href="#panel8"
-            role="tab"
-            aria-controls="panel8"
-            aria-selected="false"
-            >Tab 8</a
-         >
+      <li id="tab8" role="tab" aria-controls="panel8" aria-selected="false">
+         Tab 8
       </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab9"
-            class="env-tabs__link"
-            href="#panel9"
-            role="tab"
-            aria-controls="panel9"
-            aria-selected="false"
-            >Tab 9</a
-         >
+      <li id="tab9" role="tab" aria-controls="panel9" aria-selected="false">
+         Tab 9
       </li>
    </ul>
 </div>
@@ -223,60 +137,36 @@ Add class modifier `env-tabs--column` to tab stack container to make tabs vertic
 ```html
 <div class="env-tabs example-tabs3">
    <ul class="env-tabs__nav env-tabs--column" role="tablist">
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab10"
-            class="env-tabs__link env-tabs__link--active"
-            href="#panel10"
+      <li   id="tab10"
             role="tab"
             aria-controls="panel10"
             aria-selected="true"
-            >Tab 10</a
-         >
+            >Tab 10
       </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab11"
-            class="env-tabs__link"
-            href="#panel11"
+      <li   id="tab11"
             role="tab"
             aria-controls="panel11"
             aria-selected="false"
-            >Tab 11</a
-         >
+            >Tab 11
       </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab12"
-            class="env-tabs__link"
-            href="#panel12"
+      <li   id="tab12"
             role="tab"
             aria-controls="panel12"
             aria-selected="false"
             >Tab 12</a
          >
       </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab13"
-            class="env-tabs__link"
-            href="#panel13"
+      <li   id="tab13"
             role="tab"
             aria-controls="panel13"
             aria-selected="false"
-            >Tab 13</a
-         >
+            >Tab 13
       </li>
-      <li class="env-tabs__item" role="presentation">
-         <a
-            id="tab14"
-            class="env-tabs__link"
-            href="#panel14"
+      <li   id="tab14"
             role="tab"
             aria-controls="panel14"
             aria-selected="false"
-            >Tab 14</a
-         >
+            >Tab 14
       </li>
    </ul>
 </div>

--- a/packages/envision/src/js/tabs.js
+++ b/packages/envision/src/js/tabs.js
@@ -6,7 +6,7 @@
 
 import $ from 'jquery';
 import Util from './util/util';
-import { hide, unhide, getNodes } from './util/nodes';
+import { uniqueId, hide, unhide, getNodes } from './util/nodes';
 
 const ARIA_SELECTED = 'aria-selected';
 const ARIA_HIDDEN = 'aria-hidden';
@@ -14,7 +14,7 @@ const DATA_INDEX = 'data-env-tabs-index';
 const IS_ACTIVE = 'env-tabs__link--active';
 const NAME = 'envTabs';
 const TAB_PANEL_CLASS = 'env-tabs__panel';
-const TAB_SELECTOR = '.env-tabs__link';
+const TAB_SELECTOR = '[role="tab"]';
 const STACKED_SELECTOR = '.env-tabs--column';
 
 const DEFAULTS = {
@@ -65,14 +65,26 @@ class Tabs {
 
    initialize() {
       this.tabs.forEach((tab, i) => {
-         const panel = document.querySelector(tab.getAttribute('href'));
+         uniqueId(tab);
+         let panel = document.getElementById(tab.getAttribute('aria-controls'));
+         if (!panel) {
+            // Legacy selector fallback
+            document.querySelector(tab.getAttribute('href'));
+         }
          this.panels[tab.getAttribute('id')] = panel;
+         if (
+            tab.getAttribute(ARIA_SELECTED) === 'true' ||
+            tab.classList.contains(IS_ACTIVE)
+         ) {
+            this.config.active = i;
+         }
          tab.classList.remove(IS_ACTIVE);
          tab.setAttribute(ARIA_SELECTED, false);
          tab.setAttribute(DATA_INDEX, i);
          tab.setAttribute('tabindex', '-1');
          if (panel) {
             panel.setAttribute('tabindex', '0');
+            panel.setAttribute('role', 'tabpanel');
             panel.setAttribute(ARIA_HIDDEN, true);
             panel.classList.add(TAB_PANEL_CLASS);
             hide(panel);

--- a/packages/envision/src/scss/tab.scss
+++ b/packages/envision/src/scss/tab.scss
@@ -17,18 +17,34 @@
       }
    }
 
-   &__link {
+   &__link,
+   [role='tab'] {
       display: block;
+      align-items: center;
+      box-sizing: border-box;
+      appearance: none;
+      font-family: css-var('font-family');
+      font-size: 1em;
+      line-height: 1;
+      text-align: left;
+      color: css-var('font-color');
+      background-color: transparent;
+      border: {
+         style: none;
+         width: 0;
+         radius: 0;
+      }
+      box-shadow: none;
+      text-shadow: none;
       text-decoration: none;
+      cursor: pointer;
       transition: background-color 0.25s ease, color 0.25s ease;
       border-radius: css-var('border-radius-medium')
          css-var('border-radius-medium') 0 0;
-      background-color: transparent;
-      color: css-var('font-color');
       margin: 0 css-var('spacing-xxx-small');
       padding: css-var('spacing-x-small') css-var('spacing-medium');
 
-      &--active {
+      &[aria-selected='true'] {
          background-color: css-var('element-primary-background-color');
          color: css-var('element-primary-font-color');
       }
@@ -36,7 +52,7 @@
       @include focus-visible;
    }
 
-   &__panel {
+   &__panel[role='tabpanel'] {
       @include focus-visible;
    }
 
@@ -44,7 +60,8 @@
       @include reset-list();
       display: flex;
 
-      .env-tabs__link {
+      .env-tabs__link,
+      [role='tab'] {
          background-color: transparent;
          border-color: transparent;
          border-radius: 0;
@@ -53,7 +70,7 @@
          padding: css-var('spacing-x-small') css-var('spacing-x-small');
          transition: border-color 0.5s ease;
 
-         &--active {
+         &[aria-selected='true'] {
             border-bottom: $tab-bottom-width $border-style
                css-var('element-primary-background-color');
          }
@@ -79,10 +96,8 @@
       width: 100%;
    }
 
-   &--column > &__item {
-      a {
-         border-radius: 0;
-         margin: 0;
-      }
+   &--column [role='tab'] {
+      border-radius: 0;
+      margin: 0;
    }
 }


### PR DESCRIPTION
[All descendants are presentational](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#all_descendants_are_presentational)
"To deal with this limitation, browsers, automatically apply role [presentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) to all descendant elements of any tab element as it is a role that does not support semantic children."

Vi tillåter nu LI, BUTTON, A eller vad som helst att vara en tab. Vi kan inte kräva A-tagg med href för att det ska fungera.