### PR TITLE
Env 356 tag select update

### DIFF
--- a/packages/envision-docs/src/pages/forms/tag-select.md
+++ b/packages/envision-docs/src/pages/forms/tag-select.md
@@ -371,10 +371,10 @@ _Note: The `readonly` attribute is not supported or relevant to the Tag Select c
 - `onChange` _function(value) { ... }_
    - Invoked when the value of the control changes.
 
-- `onItemAdd` _function(value, $item) { ... }_
+- `onItemAdd` _function(value, item) { ... }_
    - Invoked when an item is selected.
 
-- `onItemRemove` _function(value) { ... }_
+- `onItemRemove` _function(value, item) { ... }_
    - Invoked when an item is deselected.
 
 - `onClear` _function() { ... }_
@@ -404,8 +404,8 @@ _Note: The `readonly` attribute is not supported or relevant to the Tag Select c
 - `onBlur` _function() { ... }_
    - Invoked when the control loses focus.
 
-- `onLoad` _function() { ... }_
-   - Invoked when new options have been loaded and added to the control via the load option.
+- `onLoad` _function(options, optgroup) { ... }_
+   - Invoked when new options have been loaded and added to the control via the load option or `load` API method.
 
 ## API functions
 
@@ -420,8 +420,8 @@ envision.select('#tag-select').then(function (selects) {
 
 ### Options
 
-- `addOptions(data)`
-   - Adds an available option, or array of options. If it already exists, nothing will happen. Note: this does not refresh the options list dropdown (use refreshOptions() for that).
+- `addOptions(data|data[])`
+   - Adds one option object or an array of option objects. If an option already exists, nothing will happen. Note: this does not refresh the options list dropdown (use `refreshOptions()` for that).
 
 - `getOption(value)`
    - Retrieves the DOM element for the option identified by the given value.
@@ -436,16 +436,7 @@ envision.select('#tag-select').then(function (selects) {
    - Refreshes the list of available options shown in the autocomplete dropdown menu.
 
 - `load(query)`
-   - Invoked when new options should be loaded from the server. Called with the current query string.
-
-- `open()`
-   - Shows the autocomplete dropdown containing the available options.
-
-- `close()`
-   - Closes the autocomplete dropdown menu.
-
-- `clear(silent)`
-   - Resets / clears all selected items from the control. If `silent` is truthy, no change event will be fired on the original input.
+   - Initiates loading options from the remote data provider for the given query string.
 
 - `clearOptions(clearFilter?)`
    - Removes all unselected options from the control. To clear selection options, call clear() before calling clearOptions().
@@ -459,7 +450,18 @@ envision.select('#tag-select').then(function (selects) {
    - Returns the DOM element of the item matching the given value.
 
 - `addItem(value, silent)`
-   - "Selects" an item. Adds it to the list at the current caret position. If silent is truthy, no change event will be fired on the original input.
+   - "Selects" an item. Adds it to the list at the current caret position. If `silent` is truthy, no change event will be fired on the original input.
+
+- `clear(silent)`
+   - Resets / clears all selected items from the control. If `silent` is truthy, no change event will be fired on the original input.
+
+### Dropdown
+
+- `open()`
+   - Shows the autocomplete dropdown containing the available options.
+
+- `close()`
+   - Closes the autocomplete dropdown menu.
 
 ### Other
 

--- a/packages/envision/package.json
+++ b/packages/envision/package.json
@@ -51,7 +51,7 @@
       "embla-carousel-autoplay": "^9.0.0-rc.0",
       "embla-carousel-fade": "^9.0.0-rc.0",
       "jquery": "^4.0.0",
-      "tom-select": "^2.4.3"
+      "tom-select": "^2.6.0"
    },
    "browserslist": [
       ">0.5%",

--- a/packages/envision/src/js/select.js
+++ b/packages/envision/src/js/select.js
@@ -15,19 +15,19 @@ const lang = {
    sv: {
       add: 'Lägg till',
       remove_button: 'Ta bort val',
-      clear_button: 'Ta bort alla val',
+      clear_button: 'Rensa',
       no_results: 'Inga alternativ matchar',
    },
    en: {
       add: 'Add',
       remove_button: 'Remove',
-      clear_button: 'Clear all',
+      clear_button: 'Clear',
       no_results: 'No results found',
    },
    no: {
       add: 'Legg til',
       remove_button: 'Fjern',
-      clear_button: 'Fjern alt',
+      clear_button: 'Tøm',
       no_results: 'Ingen resultater funnet',
    },
 };
@@ -42,13 +42,15 @@ const defaults = {
       optionClass: 'env-select__dropdown__option',
       plugins: {
          caret_position: {},
+         input_autogrow: {},
          remove_button: {
             title: `${lang.sv.remove_button}`,
             className: 'env-select__item__remove',
          },
          clear_button: {
-            title: `${lang.sv.clear_button}`,
-            className: 'env-select__input__clear',
+            html: function () {
+               return `<button class="env-select__input__clear">${lang.sv.clear_button}</button>`;
+            },
          },
       },
    },
@@ -65,6 +67,7 @@ const defaults = {
       create: false,
       clearButton: true,
       placeholder: null,
+      clearAfterSelect: true,
       sortField: function (a, b) {
          const aText = this.items[a.id].text;
          const bText = this.items[b.id].text;
@@ -98,11 +101,11 @@ const defaults = {
             );
          },
       },
-      load: null, // function() { ... }
+      load: null, // function(query, callback) { ... }
       onInitialize: null, // function() { ... }
       onChange: null, // function(value) { ... }
-      onItemAdd: null, // function(value, $item) { ... }
-      onItemRemove: null, // function(value) { ... }
+      onItemAdd: null, // function(value, item) { ... }
+      onItemRemove: null, // function(value, item) { ... }
       onClear: null, // function() { ... }
       onOptionAdd: null, // function(value, data) { ... }
       onOptionRemove: null, // function(value) { ... }
@@ -110,8 +113,8 @@ const defaults = {
       onDropdownOpen: null, // function(dropdown) { ... }
       onDropdownClose: null, // function(dropdown) { ... }
       onType: null, // function(str) { ... }
-      onFocus: null, // function(str) { ... }
-      onBlur: null, // function(str) { ... },
+      onFocus: null, // function() { ... }
+      onBlur: null, // function() { ... },
       onLoad: null, // function(options, optgroup) { ... },
       i18n: 'sv',
    },
@@ -215,6 +218,8 @@ const getSettings = (options, node) => {
    if (settings.maxItems === 1) {
       // Settings not allowed in Single select
       delete settings.plugins.clear_button;
+      delete settings.plugins.input_autogrow;
+      delete settings.plugins.caret_position;
       delete settings.plugins.remove_button;
    } else {
       // Setting only allowed for Single select
@@ -229,12 +234,35 @@ const getSettings = (options, node) => {
    }
 
    // Must remove from settings to use HTML markup
-
    ['items', 'placeholder', 'options'].forEach((prop) => {
       if (!settings[prop]) {
          delete settings[prop];
       }
    });
+
+   settings.onDropdownOpen = function (dropDnEl) {
+      // Always make dropdown visible on page
+      dropDnEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+      // Possible user added callback
+      if (typeof options.onDropdownOpen === 'function') {
+         options.onDropdownOpen.call(this, dropDnEl);
+      }
+   };
+
+   settings.onBlur = function () {
+      const input = this.control_input;
+
+      // Placeholder is not automatically restored on blur
+      if (input?.tagName === 'INPUT' && this.settings?.placeholder) {
+         input.setAttribute('placeholder', this.settings.placeholder);
+      }
+
+      // Possible user added callback
+      if (typeof options.onBlur === 'function') {
+         options.onBlur.call(this);
+      }
+   };
 
    // Handle language option
    // May be set to string 'sv', 'en' - use lang variable

--- a/packages/envision/src/js/select.js
+++ b/packages/envision/src/js/select.js
@@ -48,8 +48,9 @@ const defaults = {
             className: 'env-select__item__remove',
          },
          clear_button: {
-            html: function () {
-               return `<button class="env-select__input__clear">${lang.sv.clear_button}</button>`;
+            title: `${lang.sv.clear_button}`,
+            html: function (data) {
+               return `<button class="env-select__input__clear">${data.title}</button>`;
             },
          },
       },

--- a/packages/envision/src/js/select.js
+++ b/packages/envision/src/js/select.js
@@ -50,7 +50,7 @@ const defaults = {
          clear_button: {
             title: `${lang.sv.clear_button}`,
             html: function (data) {
-               return `<button class="env-select__input__clear">${data.title}</button>`;
+               return `<button type="button" class="env-select__input__clear">${data.title}</button>`;
             },
          },
       },
@@ -243,7 +243,12 @@ const getSettings = (options, node) => {
 
    settings.onDropdownOpen = function (dropDnEl) {
       // Always make dropdown visible on page
-      dropDnEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      dropDnEl.scrollIntoView({
+         behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches
+            ? 'auto'
+            : 'smooth',
+         block: 'nearest',
+      });
 
       // Possible user added callback
       if (typeof options.onDropdownOpen === 'function') {

--- a/packages/envision/src/scss/components/_tag-select.scss
+++ b/packages/envision/src/scss/components/_tag-select.scss
@@ -114,7 +114,7 @@
          padding: 0;
          text-align: center;
          line-height: 1.2;
-         border: none; // 1px solid;
+         border: none;
          font-family: var(--env-button-font-family);
          font-weight: var(--env-button-font-weight);
          letter-spacing: var(--env-button-letter-spacing);

--- a/packages/envision/src/scss/components/_tag-select.scss
+++ b/packages/envision/src/scss/components/_tag-select.scss
@@ -52,6 +52,7 @@
       line-height: 1;
       margin: 0;
       padding: 0.25em;
+      gap: 0.25em;
       transition:
          border-color 0.2s ease-in-out,
          box-shadow 0.2s ease-in-out;
@@ -60,52 +61,13 @@
       cursor: text;
       overflow: hidden;
 
-      .env-select.has-items & {
-         padding-bottom: 0;
-      }
-
-      .env-select.plugin-clear_button & {
-         padding-right: 1.5em;
+      .env-select.plugin-clear_button.has-items & {
+         padding-right: 3.2em;
       }
 
       > * {
          vertical-align: baseline;
          display: inline-flex;
-      }
-
-      > input {
-         background: none;
-         color: var(--env-form-input-font-color);
-         border: 0;
-         box-shadow: none;
-         display: inline-block;
-         flex: 1 1 auto;
-         font-size: 1em;
-         line-height: math.div(34, $BROWSER_FONT_SIZE);
-         margin: 0 0 0 functions.em(4px);
-         max-height: none;
-         max-width: 100%;
-         min-height: 0;
-         min-width: 7rem;
-         padding: 0;
-         text-indent: 0;
-         user-select: auto;
-
-         @include form.placeholder {
-            color: var(--env-form-input-font-color);
-            filter: opacity(0.65);
-         }
-
-         &:focus {
-            @include focus.wcagSafeOutlineNone;
-         }
-      }
-
-      .env-select.full & > input,
-      .env-select.input-hidden & > input {
-         left: -10000px;
-         opacity: 0;
-         position: absolute;
       }
 
       .env-select.focus & {
@@ -140,27 +102,39 @@
 
       &__clear {
          display: none;
+         appearance: none;
+         box-sizing: border-box;
          cursor: pointer;
          position: absolute;
-         top: calc(#{var(--env-spacing-xx-small)} + 1px);
-         right: var(--env-spacing-xxx-small);
-         color: var(--env-form-input-font-color);
-         width: 1.4em;
-         height: 1.9em;
-         line-height: 1.9;
+         top: 50%;
+         right: 1em;
+         transform: translateY(-50%);
+         min-height: 2em;
+         margin: 0;
+         padding: 0;
          text-align: center;
+         line-height: 1.2;
+         border: none; // 1px solid;
+         font-family: var(--env-button-font-family);
+         font-weight: var(--env-button-font-weight);
+         letter-spacing: var(--env-button-letter-spacing);
+         text-transform: var(--env-button-text-transform);
+         border-radius: calc(var(--env-button-border-radius) * 1);
+         font-size: var(--env-font-size-x-small);
+         background-color: transparent;
+         color: var(--env-link-font-color);
+         text-decoration: var(--env-link-text-decoration);
+
+         @include focus.focus-visible();
       }
 
-      .env-select.has-items &:hover .env-select__input__clear,
-      .env-select.has-items &:focus .env-select__input__clear,
-      .env-select.has-items.focus & .env-select__input__clear {
+      .env-select.has-items & .env-select__input__clear {
          display: block;
       }
    }
 
    &__item {
       cursor: pointer;
-      margin: 0 functions.em(4px, 14px) functions.em(4px, 14px) 0;
       align-items: center;
       display: flex;
       border-radius: var(--env-border-radius-medium);
@@ -173,14 +147,14 @@
       overflow: hidden;
       text-overflow: ellipsis;
 
-      .plugin-remove_button & {
+      .env-select.plugin-remove_button & {
          padding: 0 0 0 functions.em(10px, 14px);
       }
 
       &__remove {
          text-decoration: none !important;
          color: var(--env-element-primary-font-color);
-         padding: functions.em(9px, 14px) functions.em(7px, 14px);
+         padding: functions.em(10px, 14px) functions.em(7px, 14px);
       }
    }
 
@@ -226,5 +200,54 @@
       display: inline-block;
       margin: var(--env-spacing-small) auto 0 0;
       padding: 0 0 0 var(--env-spacing-x-small);
+   }
+}
+
+.env-select__input > input {
+   background: none;
+   color: var(--env-form-input-font-color);
+   border: 0;
+   box-shadow: none;
+   display: inline-block;
+   font-size: 1em;
+   line-height: math.div(34, $BROWSER_FONT_SIZE);
+   max-height: none;
+   max-width: 100%;
+   min-height: 0;
+   min-width: 1rem;
+   padding: 0 0 0 0.25em;
+   text-indent: 0;
+   user-select: auto;
+
+   .env-select.full & {
+      position: absolute;
+      top: -99999px;
+      left: -99999px;
+      opacity: 0;
+   }
+
+   &:last-child,
+   .env-select.plugin-clear_button &:nth-last-child(2) {
+      // Grow input only if placed last (not moved by user)
+      flex: 1 1 auto;
+      min-width: 7rem;
+   }
+
+   .env-select:not(.plugin-clear_button) &:not(:last-child),
+   .env-select.plugin-clear_button &:not(:nth-last-child(2)) {
+      // Clear button or No clear button + input moved left by using arrow keys.
+      // Placeholder might not fit. We will hide it.
+      @include form.placeholder {
+         color: transparent;
+      }
+   }
+
+   @include form.placeholder {
+      color: var(--env-form-input-font-color);
+      filter: opacity(0.65);
+   }
+
+   &:focus {
+      @include focus.wcagSafeOutlineNone;
    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5396,7 +5396,7 @@ __metadata:
     sass: "npm:^1.94.2"
     sass-loader: "npm:^16.0.6"
     terser-webpack-plugin: "npm:^5.4.0"
-    tom-select: "npm:^2.4.3"
+    tom-select: "npm:^2.6.0"
     webpack: "npm:^5.104.1"
     webpack-cli: "npm:^6.0.1"
     webpack-merge: "npm:^6.0.1"
@@ -10781,13 +10781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tom-select@npm:^2.4.3":
-  version: 2.4.3
-  resolution: "tom-select@npm:2.4.3"
+"tom-select@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "tom-select@npm:2.6.0"
   dependencies:
     "@orchidjs/sifter": "npm:^1.1.0"
     "@orchidjs/unicode-variants": "npm:^1.1.2"
-  checksum: 10c0/0567c48e31d954227ac88f53586b61f784338d97f00115c17e5fc3606552e117bdd4d53e4fa912736569daada938ef7e72092ae16d22420eab0d1bb3472b62ea
+  checksum: 10c0/02ddfd834ecfd20d8eba32785b81be89ab581cbba51db0e428e02a18b638ed615ff08119eae5c100872a97abb7c27901e841564d7cda7de2f0427f23f69e361b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. Text in the input field is cleared after selecting a tag
2. The clear-all icon has been changed to “Clear” and is now tabbable
3. When moving left between selected tags, the input field shrinks, which looks slightly better
4. Scrolls into view when the dropdown opens if it would otherwise appear outside the viewport
5. Fixed minor inaccuracies in the documentation
6. Upgraded TomSelect from 2.4.3 to 2.6.0