### PR TITLE
ENV-363 : Add Pagefind search functionality to documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs
 .DS_Store
 package-lock.json
 packages/envision-docs/static/sitevision
+packages/envision-docs/static/pagefind
 
 .yarn/*
 !.yarn/patches

--- a/packages/envision-docs/package.json
+++ b/packages/envision-docs/package.json
@@ -5,7 +5,7 @@
    "description": "Sitevision CSS framework documentation",
    "scripts": {
       "dev": "astro dev",
-      "build": "astro build",
+      "build": "astro build && pagefind --site ../../docs && cp -r ../../docs/pagefind ./static/pagefind",
       "preview": "astro preview",
       "astro": "astro"
    },
@@ -13,5 +13,8 @@
       "@astrojs/mdx": "^6.0.2",
       "astro": "^6.4.0",
       "astro-compress": "^2.4.1"
+   },
+   "devDependencies": {
+      "pagefind": "^1.5.2"
    }
 }

--- a/packages/envision-docs/src/assets/scripts/init-search.js
+++ b/packages/envision-docs/src/assets/scripts/init-search.js
@@ -1,0 +1,15 @@
+document.addEventListener('click', (e) => {
+   const link = e.target.closest('.pf-result-link');
+   if (!link) {return;}
+   const modal = document.querySelector('pagefind-modal');
+   if (modal && typeof modal.close === 'function') {
+      modal.close();
+   }
+});
+
+window.addEventListener('hashchange', () => {
+   const modal = document.querySelector('pagefind-modal');
+   if (modal && typeof modal.close === 'function') {
+      modal.close();
+   }
+});

--- a/packages/envision-docs/src/assets/scripts/mobile-nav.js
+++ b/packages/envision-docs/src/assets/scripts/mobile-nav.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-   const openButton = document.querySelector('.mobile-nav-button button');
+   const openButton = document.querySelector('.mobile-nav-open-button');
    const mobileNav = document.querySelector('.mobileNav');
    const closeButton = document.querySelector('.mobileNav__close');
    let showMobileNav = false;

--- a/packages/envision-docs/src/assets/scripts/theme-picker.js
+++ b/packages/envision-docs/src/assets/scripts/theme-picker.js
@@ -7,15 +7,18 @@
          docEl.classList.remove(darkCls);
       }
       win.sessionStorage.setItem('colorscheme', useDark ? darkCls : lightCls);
+      document.querySelectorAll('.doc-darkmode-checkbox').forEach((el) => {
+         el.checked = useDark;
+      });
    };
    document.addEventListener('DOMContentLoaded', () => {
-      const pickerEl = document.getElementById('darkMode');
-      pickerEl.addEventListener('change', (e) => {
-         switchTheme(e.target.checked);
+      document.querySelectorAll('.doc-darkmode-checkbox').forEach((el) => {
+         el.addEventListener('change', (e) => {
+            switchTheme(e.target.checked);
+         });
       });
    });
    mql.addEventListener('change', () => {
       switchTheme(mql.matches);
-      document.getElementById('darkMode').checked = mql.matches;
    });
 })(window, document.documentElement, 'doc-dark-mode', 'doc-light-mode');

--- a/packages/envision-docs/src/assets/scss/_base.scss
+++ b/packages/envision-docs/src/assets/scss/_base.scss
@@ -37,6 +37,20 @@ html {
    --doc-icon-card-header-background: #daf4e5;
    --doc-icon-text-01: #737373;
    --doc-icon-text-02: #708770;
+
+   --pf-font: var(--doc-font-family);
+   --pf-text: var(--doc-font-color);
+   --pf-text-secondary: #596157;
+   --pf-text-muted: #737373;
+   --pf-background: var(--doc-section-background-color);
+   --pf-border: var(--doc-border-color);
+   --pf-border-focus: var(--doc-color-brand);
+   --pf-hover: var(--doc-background-color);
+   --pf-mark: var(--doc-font-color);
+   --pf-outline-focus: var(--env-focus-outline-color);
+   --pf-border-radius: 4px;
+   --pf-modal-backdrop: rgba(0, 0, 0, 0.5);
+   --pf-modal-max-width: 640px;
 }
 
 .doc-dark-mode {
@@ -70,6 +84,16 @@ html {
    --doc-icon-card-header-background: #214541;
    --doc-icon-text-01: #a2bdba;
    --doc-icon-text-02: #87aaa6;
+
+   --pf-text: var(--doc-font-color);
+   --pf-text-secondary: #a2bdba;
+   --pf-text-muted: #87aaa6;
+   --pf-background: var(--doc-section-background-color);
+   --pf-border: var(--doc-border-color);
+   --pf-border-focus: var(--doc-color-brand);
+   --pf-hover: #18322f;
+   --pf-mark: var(--doc-font-color);
+   --pf-scroll-shadow: rgba(255, 255, 255, 0.1);
 }
 
 .sidenav,

--- a/packages/envision-docs/src/assets/scss/_header.scss
+++ b/packages/envision-docs/src/assets/scss/_header.scss
@@ -51,17 +51,34 @@
       display: none;
 
       @include variables.header-layout-break {
-         flex: 1;
          display: block;
-         padding: 0 1em;
+         padding: 0 1em 0 2em;
       }
    }
 
    .mobile-nav-button {
       visibility: visible;
+      display: flex;
+      align-items: center;
+      gap: 0.25em;
+
+      pagefind-modal-trigger {
+         --pf-text: var(--doc-header-font-color);
+         --pf-background: transparent;
+         --pf-border: transparent;
+         --pf-border-focus: var(--doc-color-brand);
+         --pf-outline-focus: var(--env-focus-outline-color);
+      }
+
+      .theme-picker {
+         position: static;
+         transform: none;
+         padding: 0;
+         display: block;
+      }
 
       @include variables.header-layout-break {
-         visibility: hidden;
+         display: none;
       }
    }
 
@@ -93,16 +110,39 @@
       }
    }
 
-   .theme-picker {
-      position: absolute;
-      top: 50%;
-      right: calc(#{variables.$site-padding} + 0.5em + 2.75em);
-      margin: 0;
-      padding: 0 0 0 1em;
-      transform: translateY(-50%);
+   .header-actions {
+      display: none;
 
       @include variables.header-layout-break {
-         right: variables.$site-padding;
+         display: flex;
+         flex-direction: row;
+         align-items: center;
+         gap: 0.75em;
+         margin-left: auto;
+      }
+   }
+
+   pagefind-modal-trigger {
+      --pf-text: var(--doc-header-font-color);
+      --pf-text-secondary: var(--doc-header-font-color);
+      --pf-text-muted: var(--doc-header-font-color);
+      --pf-background: transparent;
+      --pf-border: var(--doc-header-font-color);
+      --pf-border-focus: var(--doc-color-brand);
+      --pf-hover: var(--doc-background-color);
+      --pf-outline-focus: var(--env-focus-outline-color);
+      --pf-input-height: 40px;
+      --pf-border-radius: var(--env-button-border-radius);
+   }
+
+   .theme-picker {
+      display: none;
+      margin: 0;
+      padding: 0;
+
+      @include variables.header-layout-break {
+         display: flex;
+         align-items: center;
       }
 
       &__label {

--- a/packages/envision-docs/src/assets/scss/_pagefind.scss
+++ b/packages/envision-docs/src/assets/scss/_pagefind.scss
@@ -1,0 +1,29 @@
+pagefind-modal-body,
+.pf-modal-body {
+   min-height: 200px;
+
+   .pf-result-card:has([data-pf-selected]) {
+      background: var(--pf-hover) !important;
+   }
+}
+
+.pf-modal-close {
+   display: flex !important;
+}
+
+pagefind-modal-footer,
+.pf-modal-footer {
+   font-size: 14px !important;
+
+   .pf-modal-footer-key,
+   .pf-keyboard-key {
+      font-size: 12px !important;
+      height: 22px !important;
+      min-width: 22px !important;
+   }
+}
+
+pagefind-keyboard-hints,
+.pf-keyboard-hints {
+   font-size: 14px !important;
+}

--- a/packages/envision-docs/src/assets/scss/docs.scss
+++ b/packages/envision-docs/src/assets/scss/docs.scss
@@ -25,4 +25,6 @@
 @use 'demo-themes/example-brand';
 @use 'doc-themes/doc-theme-dark';
 
+@use 'pagefind';
+
 @use 'print';

--- a/packages/envision-docs/src/templates/components/Header.astro
+++ b/packages/envision-docs/src/templates/components/Header.astro
@@ -14,9 +14,17 @@ const { frontmatter } = Astro.props;
          </svg>
       </a>
       <Headernav frontmatter={frontmatter} />
-      <Themepicker />
+      <div class="header-actions">
+         <Themepicker />
+         <div class="doc-search">
+            <pagefind-modal-trigger placeholder="Search docs" hide-shortcut
+            ></pagefind-modal-trigger>
+         </div>
+      </div>
       <div class="mobile-nav-button">
-         <button class="env-button env-button--link env-button--icon">
+         <Themepicker />
+         <pagefind-modal-trigger compact hide-shortcut></pagefind-modal-trigger>
+         <button class="mobile-nav-open-button env-button env-button--link env-button--icon">
             <svg class="env-icon env-icon--xx-small">
                <use href="/sitevision/envision-icons.svg#icon-menu-line"></use>
             </svg>

--- a/packages/envision-docs/src/templates/components/Themepicker.astro
+++ b/packages/envision-docs/src/templates/components/Themepicker.astro
@@ -7,7 +7,7 @@
       Default / Dark mode
    </label>
    <div class="doc-theme-switch">
-      <input class="doc-theme-switch__checkbox" type="checkbox" id="darkMode" />
+      <input class="doc-theme-switch__checkbox doc-darkmode-checkbox" type="checkbox" id="darkMode" />
       <svg
          aria-hidden="true"
          class="env-icon doc-theme-switch__moon"
@@ -27,7 +27,9 @@
    </div>
    <script is:inline>
       if (sessionStorage.getItem('colorscheme') === 'doc-dark-mode') {
-         document.getElementById('darkMode').checked = true;
+         document.querySelectorAll('.doc-darkmode-checkbox').forEach((el) => {
+            el.checked = true;
+         });
       }
    </script>
 </div>

--- a/packages/envision-docs/src/templates/master/Master.astro
+++ b/packages/envision-docs/src/templates/master/Master.astro
@@ -19,6 +19,12 @@ import '../../../../envision/src/scss/envision.scss';
 import '../../assets/scss/docs.scss';
 
 const title = frontmatter.title;
+const pageUrl = frontmatter.url ?? Astro.url.pathname;
+const pathSegments = pageUrl.split('/').filter(Boolean);
+const shouldIndexPage =
+   pathSegments.length > 1 &&
+   !['deprecated', 'examples'].includes(pathSegments[0]) &&
+   pageUrl !== '/warnings/';
 
 // obtain Git commit hash for cache busting
 const commitHash = childProcess
@@ -49,6 +55,7 @@ const commitHash = childProcess
       }
       <link rel="alternate" type="text/plain" href="/llms.txt" />
       <link rel="alternate" type="text/plain" href="/llms-full.txt" />
+      <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
       <script is:inline>
          ((win, docEl, key) => {
             const st = win.sessionStorage;
@@ -78,6 +85,7 @@ const commitHash = childProcess
          crossorigin="anonymous"></script>
 
       <script is:inline src={`/dist/envision.js?v=${commitHash}`}></script>
+      <script type="module" src="/pagefind/pagefind-component-ui.js"></script>
       <!-- Additional head elements -->
    </head>
    <body>
@@ -98,6 +106,7 @@ const commitHash = childProcess
                <main
                   id="content"
                   class={getMainClassName(frontmatter.dashboard)}
+                  {...shouldIndexPage ? { 'data-pagefind-body': true } : {}}
                >
                   <div class="content-wrapper">
                      {
@@ -120,8 +129,10 @@ const commitHash = childProcess
          </slot>
          <Footer />
          <Mobilenav frontmatter={frontmatter} />
+         <pagefind-modal reset-on-close></pagefind-modal>
          {!!frontmatter.dashboard}
       </div>
+      <script src="../../assets/scripts/init-search.js"></script>
       <script src="../../assets/scripts/init-code-blocks.js"></script>
       <script src="../../assets/scripts/init-examples.js"></script>
       <script src="../../assets/scripts/mobile-nav.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,6 +2806,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pagefind/darwin-arm64@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@pagefind/darwin-arm64@npm:1.5.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@pagefind/darwin-x64@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@pagefind/darwin-x64@npm:1.5.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@pagefind/freebsd-x64@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@pagefind/freebsd-x64@npm:1.5.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@pagefind/linux-arm64@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@pagefind/linux-arm64@npm:1.5.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@pagefind/linux-x64@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@pagefind/linux-x64@npm:1.5.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@pagefind/windows-arm64@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@pagefind/windows-arm64@npm:1.5.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@pagefind/windows-x64@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@pagefind/windows-x64@npm:1.5.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@parcel/watcher-android-arm64@npm:2.5.1":
   version: 2.5.1
   resolution: "@parcel/watcher-android-arm64@npm:2.5.1"
@@ -5508,6 +5557,7 @@ __metadata:
     "@astrojs/mdx": "npm:^6.0.2"
     astro: "npm:^6.4.0"
     astro-compress: "npm:^2.4.1"
+    pagefind: "npm:^1.5.2"
   languageName: unknown
   linkType: soft
 
@@ -8817,6 +8867,38 @@ __metadata:
   version: 1.6.0
   resolution: "package-manager-detector@npm:1.6.0"
   checksum: 10c0/6419d0b840be64fd45bcdcb7a19f09b81b65456d5e7f7a3daac305a4c90643052122f6ac0308afe548ffee75e36148532a2002ea9d292754f1e385aa2e1ea03b
+  languageName: node
+  linkType: hard
+
+"pagefind@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "pagefind@npm:1.5.2"
+  dependencies:
+    "@pagefind/darwin-arm64": "npm:1.5.2"
+    "@pagefind/darwin-x64": "npm:1.5.2"
+    "@pagefind/freebsd-x64": "npm:1.5.2"
+    "@pagefind/linux-arm64": "npm:1.5.2"
+    "@pagefind/linux-x64": "npm:1.5.2"
+    "@pagefind/windows-arm64": "npm:1.5.2"
+    "@pagefind/windows-x64": "npm:1.5.2"
+  dependenciesMeta:
+    "@pagefind/darwin-arm64":
+      optional: true
+    "@pagefind/darwin-x64":
+      optional: true
+    "@pagefind/freebsd-x64":
+      optional: true
+    "@pagefind/linux-arm64":
+      optional: true
+    "@pagefind/linux-x64":
+      optional: true
+    "@pagefind/windows-arm64":
+      optional: true
+    "@pagefind/windows-x64":
+      optional: true
+  bin:
+    pagefind: lib/runner/bin.cjs
+  checksum: 10c0/bcc4f34f473bfeb09dc4cb464a3547bf958e11ee4dee4144ec7a364bd74b9f7c21f85be71e388b66d30923a9a453dcaed2f6b425f3e67631cadc9650ba741aab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces Pagefind to the documentation to enable full-text search functionality. The search index is generated during the build process and integrated into the site header.

Key changes include:
* Added `pagefind` as a dependency and updated the build script to generate the search index.
* Integrated the Pagefind UI modal into the header for both desktop and mobile views.
* Configured `data-pagefind-body` attributes to ensure relevant content is indexed while excluding unwanted sections.
* Added custom styling to match the Envision design system and ensure the search modal respects dark/light mode settings.
* Included a small script to handle modal closing on navigation or link selection.